### PR TITLE
change from nlopes to slack-go slack library

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/retailnext/unixtime"
 )
 


### PR DESCRIPTION
There's a series of errors about "unsupported block type" that shows up (and I ran into) https://github.com/erroneousboat/slack-term/issues/212

In looking at that, it seems that the original `nlopes` has moved on to maintaining the official-ish `slack-go` version, and when I take that (and the 269 later commits), all of my troubles seem so far away.

:)